### PR TITLE
Speedup lxml install: 104 -> 18 seconds, total time 10m24s -> 5m53s

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,9 @@ python:
 sudo: false
 
 install:
- - pip install -r requirements.txt
+ # Speedup for CI: http://lxml.de/installation.html#installation
+ - CFLAGS=-O0 pip install lxml
+ - pip install BeautifulSoup4 slacker-cli
  - pip install pep8 pyflakes
 
 script:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 BeautifulSoup4
-slacker-cli
 lxml
+slacker-cli


### PR DESCRIPTION
> To speed up the build in test environments, e.g. on a continuous integration server, disable the C compiler optimisations by setting the CFLAGS environment variable:
>
>     CFLAGS="-O0"  pip install lxml
>
> (The option reads "minus Oh Zero", i.e. zero optimisations.)

http://lxml.de/installation.html#installation

(See also: https://bugs.launchpad.net/lxml/+bug/1176147)

---

Before:

 * Ran for 4 min 1 sec
 * Total time 10 min 24 sec

Python 2.7:

`pip install -r requirements.txt` (BeautifulSoup4 lxml slacker-cli) took 106.42s

https://travis-ci.org/hugovk/lunchbot/jobs/210096608#L145

---

After:

* Ran for 1 min 56 sec
* Total time 5 min 53 sec

Python 2.7:

`CFLAGS=-O0 pip install lxml` took 17.82s and `pip install BeautifulSoup4 slacker-cli` took 1.92s

https://travis-ci.org/hugovk/lunchbot/jobs/210097490#L143
