### PR TITLE
Use container-based Trusty to use lxml wheel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,21 @@
 language: python
 
+dist: trusty
+sudo: false
+
 cache: pip
 
 # Supported CPython versions:
 # https://en.wikipedia.org/wiki/CPython#Version_history
 python:
- - pypy
  - 2.7
  - 3.6
  - 3.5
  - 3.4
  - 3.3
 
-sudo: false
-
 install:
- # Speedup for CI: http://lxml.de/installation.html#installation
- - CFLAGS=-O0 pip install lxml
- - pip install BeautifulSoup4 slacker-cli
+ - pip install -r requirements.txt
  - pip install pep8 pyflakes
 
 script:


### PR DESCRIPTION
Baseline (with pypy): builds lxml from cached source
---

 Ran for 1 min 54 sec
 Total time 5 min 51 sec

Python 2.7:
* 20.82s `CFLAGS=-O0 pip install lxml`

https://travis-ci.org/hugovk/lunchbot/jobs/210126557#L145

Cache 0 (no pypy): no cache available yet, installs lxml from downloaded wheel
---

 Ran for 2 min 25 sec
 Total time 9 min 19 sec

Cache 1 (no pypy): cache available, installs lxml from cached wheel
---

 Ran for 1 min 19 sec
 Total time 4 min 51 sec

Python 2.7:
 * 2.85s `pip install BeautifulSoup4 lxml slacker-cli`

https://travis-ci.org/hugovk/lunchbot/jobs/210127215#L119