### PR TITLE
Escape apostrophes

### DIFF
--- a/lunchbot.py
+++ b/lunchbot.py
@@ -236,6 +236,11 @@ if __name__ == "__main__":
 
         print(menu.encode("utf8"))
 
+        # Escape ' like in "Pasta all'amatriciana" by
+        # replacing ' with '"'"'
+        # https://stackoverflow.com/a/1250279/724176
+        menu = menu.replace("'", "'\"'\"'")
+
         if not args.dry_run:
 
             if args.user:


### PR DESCRIPTION
It was falling over on "Pasta all'amatrician" because it called `echo 'menu text here' | command_to_post_to_slack`.
The fix is to replace the `'` with `'"'"'` because https://stackoverflow.com/a/1250279/724176 and escape a bit more in Python.