### PR TITLE
Retry on HTTP error

### DIFF
--- a/lunchbot.py
+++ b/lunchbot.py
@@ -14,7 +14,7 @@ import datetime
 import os
 import random
 import traceback
-from urllib.request import urlopen
+import urllib
 
 from bs4 import BeautifulSoup  # pip install BeautifulSoup4 lxml
 
@@ -126,7 +126,7 @@ def day_name_en(day_number):
 
 def get_soup(url):
     """Not that kind"""
-    page = urlopen(url)
+    page = urllib.request.urlopen(url)
     soup = BeautifulSoup(page.read(), "lxml")
     for br in soup.find_all("br"):
         br.replace_with("\n")
@@ -422,7 +422,12 @@ if __name__ == "__main__":
         # Like getting lunch_savel()
         restaurant_function = locals()[function]
 
-        do_restaurant(restaurant_function, args.dry_run, args.user)
-
+        tries = 0
+        while tries < 3:
+            tries += 1
+            try:
+                do_restaurant(restaurant_function, args.dry_run, args.user)
+            except urllib.error.HTTPError as e:
+                print(e)
 
 # End of file

--- a/lunchbot.py
+++ b/lunchbot.py
@@ -336,6 +336,44 @@ def lunch_lounaat(restaurant):
     return "\n".join(todays_menu)
 
 
+def do_restaurant(restaurant_function, dry_run, user):
+    """Get the menu for a restaurant and post to Slack"""
+    try:
+        menu = restaurant_function()
+    except AttributeError:
+        print(restaurant_function.__name__)
+        traceback.print_exc()
+        return
+
+    # Remove &nbsp; chars
+    menu = menu.replace("\xa0", "")
+    # Squeeze out repeated newlines
+    menu = squeeze("\n", menu)
+
+    print(menu)
+
+    # Escape ' like in "Pasta all'amatriciana" by
+    # replacing ' with '"'"'
+    # https://stackoverflow.com/a/1250279/724176
+    menu = menu.replace("'", "'\"'\"'")
+
+    if not dry_run:
+
+        if user:
+            target = f"-u {args.user}"
+        else:
+            target = "-c lunch"
+
+        slacker_cmd = ("slacker -t $LUNCHBOT_TOKEN -n LunchBot -i {} {}").format(
+            random.choice(EMOJI), target
+        )
+        # print(slacker_cmd)
+
+        cmd = f"echo '{menu}' | {slacker_cmd}"
+        # print(cmd.encode("utf8"))
+        os.system(cmd)
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Post what's for lunch at local restaurants to Slack",
@@ -379,43 +417,12 @@ if __name__ == "__main__":
 
     for restaurant in restaurants:
 
-        try:
-            # Call function from a string
-            function = "lunch_" + restaurant
-            # Like calling lunch_savel()
-            menu = locals()[function]()
+        # Call function from a string
+        function = "lunch_" + restaurant
+        # Like getting lunch_savel()
+        restaurant_function = locals()[function]
 
-        except AttributeError:
-            print(restaurant)
-            traceback.print_exc()
-            continue
+        do_restaurant(restaurant_function, args.dry_run, args.user)
 
-        # Remove &nbsp; chars
-        menu = menu.replace("\xa0", "")
-        # Squeeze out repeated newlines
-        menu = squeeze("\n", menu)
-
-        print(menu)
-
-        # Escape ' like in "Pasta all'amatriciana" by
-        # replacing ' with '"'"'
-        # https://stackoverflow.com/a/1250279/724176
-        menu = menu.replace("'", "'\"'\"'")
-
-        if not args.dry_run:
-
-            if args.user:
-                target = f"-u {args.user}"
-            else:
-                target = "-c lunch"
-
-            slacker_cmd = ("slacker -t $LUNCHBOT_TOKEN -n LunchBot -i {} {}").format(
-                random.choice(EMOJI), target
-            )
-            # print(slacker_cmd)
-
-            cmd = f"echo '{menu}' | {slacker_cmd}"
-            # print(cmd.encode("utf8"))
-            os.system(cmd)
 
 # End of file


### PR DESCRIPTION
To avoid things like this, and at least let it continue with the others:

```
:Pompier_Espa: Pompier Espa https://www.lounaat.info/lounas/pompier-espa/helsinki
13e
Ehta-salaattipöytä sekä punajuurisosekeittoa ja vuohenjuustomoussea
11e
Pannupihvi härän paistista, karamellisoitua sipulia ja lohkoperunoita
19e
Kaikki herkut
11-14 140m
Traceback (most recent call last):
  File "/home/botuser/github/lunchbot/lunchbot.py", line 386, in <module>
    menu = locals()[function]()
  File "/home/botuser/github/lunchbot/lunchbot.py", line 239, in lunch_pihka
    soup = get_soup(url)
  File "/home/botuser/github/lunchbot/lunchbot.py", line 129, in get_soup
    page = urlopen(url)
  File "/usr/lib/python3.6/urllib/request.py", line 223, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib/python3.6/urllib/request.py", line 532, in open
    response = meth(req, response)
  File "/usr/lib/python3.6/urllib/request.py", line 642, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/lib/python3.6/urllib/request.py", line 570, in error
    return self._call_chain(*args)
  File "/usr/lib/python3.6/urllib/request.py", line 504, in _call_chain
    result = func(*args)
  File "/usr/lib/python3.6/urllib/request.py", line 650, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 500: Internal Server Error
```