### PR TITLE
Replace 3.9-dev with 3.9 in CI and use it for linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ cache:
 matrix:
   fast_finish: true
   include:
-    - python: 3.8
+    - python: 3.9
       env: TOXENV=lint
     - python: 3.10-dev
-    - python: 3.9-dev
+    - python: 3.9
     - python: 3.8
     - python: 3.7
     - python: 3.6


### PR DESCRIPTION
because this repository was mentioned here:
https://github.com/hugovk/pypistats/issues/181